### PR TITLE
When amt isn't available, set to false.  The

### DIFF
--- a/ipmi/script/roles/amt-discover/01-amt-discover.sh
+++ b/ipmi/script/roles/amt-discover/01-amt-discover.sh
@@ -2,4 +2,6 @@
 
 if [[ -d /sys/module/mei_me ]] && grep -q mei_me < <(dmesg); then
     write_attribute 'amt/enable' true
+else
+    write_attribute 'amt/enable' false
 fi


### PR DESCRIPTION
system expects the wall to be set (not the attribute).