### PR TITLE
Add MX[23]0 support.  It appears that it should work.

### DIFF
--- a/bios/rebar.yml
+++ b/bios/rebar.yml
@@ -68,7 +68,7 @@ roles:
              "system_product":
                "__sm_leaf": true,
                "op": "regex"
-               "match": "^PowerEdge (R.|T[34])[23]0"
+               "match": "^PowerEdge (M.|R.|T[34])[23]0"
             "role": "bios-dell-rseries-configure"
             "configs":
               - "name": "default"

--- a/bios/rebar_engine/barclamp_bios/app/models/barclamp_bios/dellrseries.rb
+++ b/bios/rebar_engine/barclamp_bios/app/models/barclamp_bios/dellrseries.rb
@@ -62,7 +62,7 @@ class BarclampBios::Dellrseries < BarclampBios::Driver
           min_length = (item.MinLength.text.to_i rescue nil) || 0
           max_length = (item.MaxLength.text.to_i rescue nil) || 65535
           validate_re = item.ValueExpression.text
-          validate_re = /#{validate_re.empty? ? '^.*$' : validate_re}/
+          validate_re = /#{(validate_re.nil? || validate_re.empty?) ? '^.*$' : validate_re}/
           i["validator"] = {
             "length" => (min_length..max_length),
             "regex" => validate_re

--- a/raid/rebar.yml
+++ b/raid/rebar.yml
@@ -93,6 +93,9 @@ roles:
       - name: raid-debug
         description: "Whether to run the RAID recipes with debugging enabled"
         map: 'raid/debug'
+        default: false
+        schema:
+          type: bool
   - name: raid-configure
     jig: role-provided
     flags:


### PR DESCRIPTION
Add raid-debug settable schema - default to false
Handle cause where Strings don't return validators.