### PR TITLE
Update hardware barclamp to use preceeds

### DIFF
--- a/bios/rebar.yml
+++ b/bios/rebar.yml
@@ -34,10 +34,9 @@ roles:
     flags:
       - implicit
       - discovery
-    attaches:
-      - rebar-hardware-configured
-    requires:
+    preceeds:
       - rebar-managed-node
+    requires:
       - provisioner-service
     attribs:
       - name: bios-set-mapping
@@ -464,6 +463,8 @@ roles:
       - leaverunlog
     requires:
       - bios-discover
+    preceeds:
+      - rebar-hardware-configured
     wants-attribs:
       - bios-config-sets
       - ipmi-macaddr
@@ -488,6 +489,8 @@ roles:
       - leaverunlog
     requires:
       - bios-discover
+    preceeds:
+      - rebar-hardware-configured
     wants-attribs:
       - bios-config-sets
     attribs:

--- a/bios/rebar_engine/barclamp_bios/app/models/barclamp_bios/discover.rb
+++ b/bios/rebar_engine/barclamp_bios/app/models/barclamp_bios/discover.rb
@@ -56,7 +56,6 @@ class BarclampBios::Discover < Role
         runlog << "Adding #{bc_role.name} to #{nr.node.name}"
         bc_noderole = bc_role.add_to_node(nr.node)
         chc_noderole = chc_role.add_to_node(nr.node)
-        bc_noderole.add_child(chc_noderole)
         nr.runlog = runlog.join("\n")
       end
     else

--- a/ipmi/rebar.yml
+++ b/ipmi/rebar.yml
@@ -66,6 +66,8 @@ roles:
     type: 'BarclampIpmi::AmtConfigure'
     requires:
       - amt-discover
+    preceeds:
+      - rebar-managed-node
     wants-attribs:
       - node-control-address
       - amt-enable
@@ -78,7 +80,7 @@ roles:
           type: str
   - name: ipmi-discover
     jig: chef
-    attaches:
+    preceeds:
       - rebar-managed-node
     requires:
       - deployer-client
@@ -312,6 +314,8 @@ roles:
     wants-attribs:
       - ipmi-enable
       - ipmi-detected-params
+    preceeds:
+      - rebar-managed-node
     events:
       - endpoint: inproc://role:ipmi-configure/on_active
         selectors:

--- a/ipmi/rebar_engine/barclamp_ipmi/app/models/barclamp_ipmi/amt_discover.rb
+++ b/ipmi/rebar_engine/barclamp_ipmi/app/models/barclamp_ipmi/amt_discover.rb
@@ -21,8 +21,6 @@ class BarclampIpmi::AmtDiscover < Role
     return if NodeRole.find_by(node_id: nr.node_id, role_id: config_role.id)
     config_nr = config_role.add_to_node_in_deployment(nr.node,nr.deployment)
     config_nr.commit!
-    config_nr.add_child('rebar-managed-node')
   end
 
 end
-

--- a/ipmi/rebar_engine/barclamp_ipmi/app/models/barclamp_ipmi/discover.rb
+++ b/ipmi/rebar_engine/barclamp_ipmi/app/models/barclamp_ipmi/discover.rb
@@ -76,10 +76,6 @@ class BarclampIpmi::Discover < Role
       # Force the config role into the same deployment as the discover role
       ipmi_config = icr_role.add_to_node_in_deployment(nr.node, nr.deployment)
       ipmi_config.commit!
-      # Keep the noderole graph sane by making the managed_node role for this node
-      # depend on our newly-added ipmi config noderole.
-      Rails.logger.info("Making rebar-managed-node on #{nr.node.name} depend on ipmi-configure role.")
-      ipmi_config.add_child('rebar-managed-node')
     end
   end
 end

--- a/raid/rebar.yml
+++ b/raid/rebar.yml
@@ -25,7 +25,6 @@ roles:
     jig: chef
     requires:
       - provisioner-service
-      - rebar-managed-node
     flags:
       - implicit
     events:
@@ -88,8 +87,8 @@ roles:
     flags:
       - discovery
       - implicit
-    attaches:
-      - rebar-hardware-configured
+    preceeds:
+      - rebar-managed-node
     requires:
       - raid-tools-install
     attribs:
@@ -109,6 +108,9 @@ roles:
       - destructive
     requires:
       - raid-discover
+      - rebar-managed-node
+    preceeds:
+      - rebar-hardware-configured
     attribs:
       - name: raid-enable
         description: "Whether or not to use the RAID controllers on a specific node."

--- a/raid/rebar_engine/barclamp_raid/app/models/barclamp_raid/discover.rb
+++ b/raid/rebar_engine/barclamp_raid/app/models/barclamp_raid/discover.rb
@@ -37,7 +37,6 @@ class BarclampRaid::Discover < Role
     # Force these nodes into the same deployment
     rpc_noderole = rpc_role.add_to_node(nr.node)
     chc_noderole = chc_role.add_to_node(nr.node)
-    rpc_noderole.add_child(chc_noderole)
   end
 
   def update_log(nr, string)


### PR DESCRIPTION
This gets rid of a tiny bit of custom logic in the -discover roles.