### PR TITLE
Actually add the hard reset quirk for HP ILO.

### DIFF
--- a/ipmi/rebar.yml
+++ b/ipmi/rebar.yml
@@ -159,7 +159,7 @@ roles:
                   "match": "256 (0x0100)"
                   "score": 3
           "hp-19-11-bmc":
-            "quirklist": ["ipmi-crossed-access-channels"]
+            "quirklist": ["ipmi-crossed-access-channels","ipmi-hard-reset-after-config"]
             "match":
               "bmcinfo":
                 "device_id":


### PR DESCRIPTION
This might not be needed for all ilo systems, but until we have a
chance to more thuroughly troubleshoot things here we are.